### PR TITLE
Adds optional VTK support, informative error on obj files with "vn" in them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.4.6)
+cmake_minimum_required(VERSION 2.6)
 Project("SDFGen")
 
 # Set the build type.  Options are:
@@ -12,14 +12,28 @@ Project("SDFGen")
 SET(CMAKE_BUILD_TYPE Release)
 
 #set the default path for built executables to the "bin" directory
-set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
+set(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin)
 
 #These flags might not work on every system, especially the release flags, comment out as needed
 set(CMAKE_CXX_FLAGS "-O3")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -msse4.2 -mfpmath=sse -mtune=native -march=native")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native")
 
+#checks if VTK is available
+find_package(VTK QUIET)
+if(VTK_FOUND)
+	set(HAVE_VTK 1)
+endif()
 
-add_executable(${PROJECT_NAME}
-main.cpp  makelevelset3.cpp array1.h  array2.h  array3.h  hashgrid.h  hashtable.h makelevelset3.h  util.h  vec.h
+#Generates config.h replacing expressions in config.h.in with actual values
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/config.h.in"
+  "${CMAKE_CURRENT_SOURCE_DIR}/config.h"
 )
+
+add_executable(${PROJECT_NAME} main.cpp  makelevelset3.cpp)
+
+if(VTK_FOUND)
+	include_directories(${VTK_INCLUDE_DIRS})
+	target_link_libraries(${PROJECT_NAME} ${VTK_LIBRARIES})
+endif()

--- a/config.h.in
+++ b/config.h.in
@@ -1,0 +1,11 @@
+#ifndef SDFGEN_CONFIG_H
+#define SDFGEN_CONFIG_H
+
+/*
+ * Configuration Header for SDFGEN
+ */
+ 
+/// Configured libraries
+#cmakedefine HAVE_VTK
+
+#endif //SDFGEN_CONFIG_H


### PR DESCRIPTION
This added optional dependency should produce no change for users who don't have vtk installed, except that obj files containing vertex normals will cause the program to exit instead of crashing. 

Others will have a vti image file as output instead of an sdf file. VTI images can be opened with paraview ( http://www.paraview.org/ ) which is a great open-source tool for visualization of volumetric data.